### PR TITLE
Implement custom indexing solution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,16 +206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv-index"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f274135fcb98bd7e6e47a9e0b44639ec53b3e5d6c1930e2a9e6a014f90470404"
-dependencies = [
- "byteorder",
- "csv",
-]
-
-[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,7 +220,6 @@ version = "0.1.0"
 dependencies = [
  "config",
  "csv",
- "csv-index",
  "hyper",
  "lazy_static",
  "log 0.4.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [dependencies]
 config = { version = "~0.10.1", default_features = false, features = ["json", "yaml"] }
 csv = "~1.1.3"
-csv-index = "~0.1.6"
 hyper = "~0.13.2"
 log = "~0.4.8"
 pretty_env_logger = "~0.4.0"


### PR DESCRIPTION
Closes #14. Closes #15.

Instead of using `csv-index`'s `RandomAccessSimple` (which relies heavily upon mutable access to an underlying cursor and does not provide a `get`) we simply use a `HashMap` of `LogicalRecordNumber` to `u64` (offset from start of the file).

I'll be optimizing this later.