### PR TITLE
server: Implement advanced cached loading, routing of shapefiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,6 +1611,7 @@ version = "0.1.0"
 dependencies = [
  "config",
  "distringo",
+ "futures",
  "geo",
  "geojson",
  "http",
@@ -1781,6 +1782,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "slab",
  "tokio-macros",

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: DISTRINGO_PORT=$PORT ./target/release/distringo
+

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,13 +8,14 @@ edition = "2018"
 
 [dependencies]
 config = { version = "~0.10.1", default_features = false, features = ["json", "yaml"] }
+futures = { version = "~0.3" }
 geo = "~0.14.1"
 geojson = "~0.19.0"
 http = "~0.2.1"
 hyper = "~0.13.7"
 log = "~0.4.8"
 pretty_env_logger = "~0.4.0"
-tokio = { version = "~0.2.21", features = ["macros"] }
+tokio = { version = "~0.2.21", features = ["macros", "rt-threaded"] }
 warp = { version = "~0.2.3", features = ["compression"] }
 lazy_static = "~1.4.0"
 serde = { version = "~1.0.114", features = ["derive"] }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -63,6 +63,8 @@ impl ExecutionPlan {
 			SocketAddr::new(host, port)
 		};
 
-		Ok(server(&self.0)?.run(socket).await)
+		server(&self.0)?.run(socket).await;
+
+		Ok(())
 	}
 }

--- a/server/src/server/routes/api.rs
+++ b/server/src/server/routes/api.rs
@@ -1,55 +1,78 @@
 use shapefiles::{Shapefile, ShapefileConfiguration};
 
-use core::convert::TryInto;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use warp::Filter;
 
 pub mod shapefiles;
 
+mod cache {
+	use super::{Shapefile, ShapefileConfiguration};
+	use std::collections::HashMap;
+	use std::convert::TryInto;
+	use std::mem::MaybeUninit;
+	use std::sync::Once;
+
+	mod internal {
+		use super::{HashMap, MaybeUninit, Once, Shapefile};
+		pub(super) static mut CACHE: MaybeUninit<HashMap<String, Shapefile>> = MaybeUninit::uninit();
+		pub(super) static CACHE_INIT: Once = Once::new();
+	}
+
+	pub(super) fn get_cache(cfg: &config::Config) -> &'static HashMap<String, Shapefile> {
+		// SAFETY: Here we use the `static mut`-`Once` pattern to ensure that the code
+		// to initialize the contents of LOADED_SHAPEFILES beyond the starting value
+		// `HashMap::new()` is called only once.
+		//
+		// We use `MaybeUninit` to get a blank spot to put our `HashMap` into.
+		//
+		//
+		internal::CACHE_INIT.call_once(|| {
+			unsafe {
+				internal::CACHE = MaybeUninit::new(HashMap::new());
+			}
+
+			if let Ok(configuration) = cfg.get_table("shapefiles") {
+				configuration
+					.iter()
+					.filter_map(|(id, value)| -> Option<(String, Shapefile)> {
+						// TODO(rye): avoid clone by iterating over keys and using remove?
+						let value: config::Value = value.clone();
+						// TODO(rye): handle error a bit better
+						let config: ShapefileConfiguration = value.try_into().expect("invalid configuration");
+						let shapefile: distringo::Result<Shapefile> = config.try_into();
+						if let Ok(shapefile) = shapefile {
+							Some((id.to_string(), shapefile))
+						} else {
+							log::warn!("Error parsing shapefile {}: {:?}", id, shapefile);
+							None
+						}
+					})
+					.for_each(|(id, shp): (String, Shapefile)| unsafe {
+						(*internal::CACHE.as_mut_ptr()).insert(id, shp);
+					});
+			};
+		});
+		unsafe { &*internal::CACHE.as_ptr() }
+	}
+}
+
 pub fn shapefiles(
 	cfg: &config::Config,
 ) -> distringo::Result<warp::filters::BoxedFilter<(impl warp::Reply,)>> {
-	let shapefiles: HashMap<String, config::Value> = cfg.get_table("shapefiles")?;
-
-	let shapefiles: HashMap<String, Shapefile> = shapefiles
-		.iter()
-		.filter_map(
-			|(id, value): (&String, &config::Value)| -> Option<(String, Shapefile)> {
-				// TODO(rye): avoid clone by iterating over keys and using remove?
-				let value: config::Value = value.clone();
-				// TODO(rye): handle error a bit better
-				let config: ShapefileConfiguration = value.try_into().expect("invalid configuration");
-				let shapefile: distringo::Result<Shapefile> = config.try_into();
-				if let Ok(shapefile) = shapefile {
-					Some((id.to_string(), shapefile))
-				} else {
-					log::warn!("Error parsing shapefile {}: {:?}", id, shapefile);
-					None
-				}
-			},
-		)
-		.collect();
-
-	let shapefiles: Arc<HashMap<String, Shapefile>> = Arc::new(shapefiles);
+	let loaded_shapefiles: &'static HashMap<String, Shapefile> = cache::get_cache(cfg);
 
 	// GET /api/v0/shapefiles
-	let shapefiles_index = {
-		let shapefiles = shapefiles.clone();
-		warp::get()
-			.and(warp::path::end())
-			.map(move || shapefiles::index(&shapefiles))
-	};
+	let shapefiles_index = warp::get()
+		.and(warp::path::end())
+		.map(move || shapefiles::index(loaded_shapefiles));
+
 	// GET /api/v0/shapefiles/:id
-	let shapefiles_show = {
-		#[allow(clippy::redundant_clone)]
-		let shapefiles = shapefiles.clone();
-		warp::get()
-			.and(warp::path!(String))
-			.map(move |id: String| shapefiles::show(&shapefiles, &id))
-			.with(warp::compression::gzip())
-	};
+	let shapefiles_show = warp::get()
+		.and(warp::path!(String))
+		.map(move |id: String| shapefiles::show(loaded_shapefiles, &id))
+		.with(warp::compression::gzip());
+
 	// ... /api/v0/shapefiles/...
 	let shapefiles = warp::any()
 		.and(warp::path!("shapefiles" / ..))
@@ -73,5 +96,5 @@ pub fn api(
 
 	let gets = shapefiles;
 
-	Ok(warp::any().and(api.or(api_v0).unify()).and(gets).boxed())
+	Ok(warp::any().and(api.or(api_v0)).unify().and(gets).boxed())
 }

--- a/server/src/server/routes/api/shapefiles.rs
+++ b/server/src/server/routes/api/shapefiles.rs
@@ -124,8 +124,10 @@ mod tests {
 			let map: &'static HashMap<String, Shapefile> = {
 				use core::mem::MaybeUninit;
 				static mut INNER: MaybeUninit<HashMap<String, Shapefile>> = MaybeUninit::uninit();
-				unsafe { INNER = MaybeUninit::new(HashMap::new()) };
-				unsafe { &mut *INNER.as_mut_ptr() }.insert(id.clone(), shapefile);
+				std::sync::Once::new().call_once(|| {
+					unsafe { INNER = MaybeUninit::new(HashMap::new()) };
+					unsafe { &mut *INNER.as_mut_ptr() }.insert(id.clone(), shapefile);
+				});
 				unsafe { &*INNER.as_ptr() }
 			};
 

--- a/server/src/server/routes/api/shapefiles.rs
+++ b/server/src/server/routes/api/shapefiles.rs
@@ -112,7 +112,7 @@ mod tests {
 			let contents = GeoJson::Geometry(Geometry::new(Point(vec![0.0_f64, 0.0_f64])));
 			let shapefile = Shapefile {
 				ty: ShapefileType::TabularBlock,
-				data: contents.to_string().into(),
+				data: contents.to_string(),
 				contents,
 			};
 

--- a/server/src/server/routes/api/shapefiles.rs
+++ b/server/src/server/routes/api/shapefiles.rs
@@ -30,8 +30,7 @@ impl<'buffer> futures::Stream for ByteChunkStream<'buffer> {
 	type Item = Result<&'buffer [u8], std::convert::Infallible>;
 
 	fn poll_next(self: Pin<&mut Self>, _ctx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-		let next: Option<Result<&'buffer [u8], _>> =
-			self.get_mut().iterator.next().map(|chunk| Ok(chunk));
+		let next: Option<Result<&'buffer [u8], _>> = self.get_mut().iterator.next().map(Ok);
 		Poll::Ready(next)
 	}
 }

--- a/server/src/server/routes/api/shapefiles.rs
+++ b/server/src/server/routes/api/shapefiles.rs
@@ -80,19 +80,15 @@ pub fn show(
 	if let Some(shapefile) = shapefiles.get(id) {
 		let data: &str = &shapefile.data;
 
-		let response = {
-			http::response::Builder::new()
-				.status(hyper::StatusCode::OK)
-				.header(hyper::header::CONTENT_TYPE, "application/vnd.geo+json")
-				.header(hyper::header::CACHE_CONTROL, "public")
-				// TODO(rye): Clean up error path
-				.body(hyper::body::Body::wrap_stream(ByteChunkStream::new(
-					data, 4096,
-				)))
-				.unwrap()
-		};
-
-		response
+		http::response::Builder::new()
+			.status(hyper::StatusCode::OK)
+			.header(hyper::header::CONTENT_TYPE, "application/vnd.geo+json")
+			.header(hyper::header::CACHE_CONTROL, "public")
+			// TODO(rye): Clean up error path
+			.body(hyper::body::Body::wrap_stream(ByteChunkStream::new(
+				data, 4096,
+			)))
+			.unwrap()
 	} else {
 		log::debug!("{:?}", shapefiles);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,21 @@ pub enum Error {
 	InvalidServerPort,
 }
 
+impl core::fmt::Display for Error {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::result::Result<(), std::fmt::Error> {
+		match self {
+			Error::Io(inner) => writeln!(f, "io error: {}", inner),
+			Error::Csv(inner) => writeln!(f, "csv error: {}", inner),
+			Error::Config(inner) => writeln!(f, "config error: {}", inner),
+			Error::GeoJson(inner) => writeln!(f, "geojson error: {}", inner),
+			_ => todo!(),
+		}
+	}
+}
+
 pub type Result<T> = result::Result<T, Error>;
+
+impl std::error::Error for Error {}
 
 impl From<io::Error> for Error {
 	fn from(e: io::Error) -> Error {


### PR DESCRIPTION
This is primarily done so as to have the ability to send back responses with the `'static` lifetime (required by `hyper` for its sending somesuch, apparently).

I must use `unsafe` because RAII guard-based things cannot be `'static`, and also are `!Sync`.

This works, and sends back the response in about 300ms on my laptop.

More work might be needed to get the TTFB down for browsers, but ~1s to load a 5M dataset over the network is probably… okay.