### PR TITLE
server: Switch to once_cell::sync::OnceCell for cache storage

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,7 @@ geojson = "~0.19.0"
 http = "~0.2.1"
 hyper = "~0.13.7"
 log = "~0.4.8"
+once_cell = "~1.4.0"
 pretty_env_logger = "~0.4.0"
 tokio = { version = "~0.2.21", features = ["macros", "rt-threaded"] }
 warp = { version = "~0.2.3", features = ["compression"] }

--- a/server/src/server/routes/api.rs
+++ b/server/src/server/routes/api.rs
@@ -2,58 +2,45 @@ use shapefiles::{Shapefile, ShapefileConfiguration};
 
 use std::collections::HashMap;
 
+use once_cell::sync::OnceCell;
 use warp::Filter;
 
 pub mod shapefiles;
 
 mod cache {
-	use super::{Shapefile, ShapefileConfiguration};
+	use super::{OnceCell, Shapefile, ShapefileConfiguration};
 	use std::collections::HashMap;
 	use std::convert::TryInto;
-	use std::mem::MaybeUninit;
-	use std::sync::Once;
 
-	mod internal {
-		use super::{HashMap, MaybeUninit, Once, Shapefile};
-		pub(super) static mut CACHE: MaybeUninit<HashMap<String, Shapefile>> = MaybeUninit::uninit();
-		pub(super) static CACHE_INIT: Once = Once::new();
-	}
+	static CACHE: OnceCell<HashMap<String, Shapefile>> = OnceCell::new();
 
 	pub(super) fn get_cache(cfg: &config::Config) -> &'static HashMap<String, Shapefile> {
-		// SAFETY: Here we use the `static mut`-`Once` pattern to ensure that the code
-		// to initialize the contents of LOADED_SHAPEFILES beyond the starting value
-		// `HashMap::new()` is called only once.
-		//
-		// We use `MaybeUninit` to get a blank spot to put our `HashMap` into.
-		//
-		//
-		internal::CACHE_INIT.call_once(|| {
-			unsafe {
-				internal::CACHE = MaybeUninit::new(HashMap::new());
-			}
+		let mut cache = HashMap::new();
 
-			if let Ok(configuration) = cfg.get_table("shapefiles") {
-				configuration
-					.iter()
-					.filter_map(|(id, value)| -> Option<(String, Shapefile)> {
-						// TODO(rye): avoid clone by iterating over keys and using remove?
-						let value: config::Value = value.clone();
-						// TODO(rye): handle error a bit better
-						let config: ShapefileConfiguration = value.try_into().expect("invalid configuration");
-						let shapefile: distringo::Result<Shapefile> = config.try_into();
-						if let Ok(shapefile) = shapefile {
-							Some((id.to_string(), shapefile))
-						} else {
-							log::warn!("Error parsing shapefile {}: {:?}", id, shapefile);
-							None
-						}
-					})
-					.for_each(|(id, shp): (String, Shapefile)| unsafe {
-						(*internal::CACHE.as_mut_ptr()).insert(id, shp);
-					});
-			};
-		});
-		unsafe { &*internal::CACHE.as_ptr() }
+		if let Ok(configuration) = cfg.get_table("shapefiles") {
+			configuration
+				.iter()
+				.filter_map(|(id, value)| -> Option<(String, Shapefile)> {
+					// TODO(rye): avoid clone by iterating over keys and using remove?
+					let value: config::Value = value.clone();
+					// TODO(rye): handle error a bit better
+					let config: ShapefileConfiguration = value.try_into().expect("invalid configuration");
+					let shapefile: distringo::Result<Shapefile> = config.try_into();
+					if let Ok(shapefile) = shapefile {
+						Some((id.to_string(), shapefile))
+					} else {
+						log::warn!("Error parsing shapefile {}: {:?}", id, shapefile);
+						None
+					}
+				})
+				.for_each(|(id, shp): (String, Shapefile)| {
+					cache.insert(id, shp);
+				});
+		};
+
+		CACHE.set(cache).expect("cache already initialized");
+
+		CACHE.get().unwrap()
 	}
 }
 

--- a/server/src/server/routes/api/shapefiles.rs
+++ b/server/src/server/routes/api/shapefiles.rs
@@ -1,6 +1,8 @@
 use core::convert::TryFrom;
-use geojson::GeoJson;
+
 use std::path::Path;
+
+use geojson::GeoJson;
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
This makes things... quite a bit easier!  Now, no need for unsafe.

OnceCell properly yells at us if something goes wrong, but it has the API we need, taking full ownership of a local from the init function as I kinda wanted from the get-go.