### PR TITLE
IndexedDataset: Switch to 2010-style GEOIDs

### DIFF
--- a/src/dataset/indexed.rs
+++ b/src/dataset/indexed.rs
@@ -248,7 +248,7 @@ impl IndexedDataset {
 						let split: Vec<&str> = buf.split('|').collect();
 
 						let logrecno = split[7];
-						let geoid = split[8];
+						let geoid = split[9];
 
 						Some((logrecno.parse()?, geoid.to_string(), pos))
 					}

--- a/tests/load_2020.rs
+++ b/tests/load_2020.rs
@@ -143,10 +143,10 @@ fn main() -> distringo::Result<()> {
 		vec![&rec_a, &rec_b, &rec_c]
 	);
 
-	let logrecno = ds.get_logical_record_number_for_geoid("7500000US440070184001012")?;
+	let logrecno = ds.get_logical_record_number_for_geoid("440070184001012")?;
 	assert_eq!(logrecno, 19_200);
 
-	let header = ds.get_header_for_geoid("7500000US440070184001012")?;
+	let header = ds.get_header_for_geoid("440070184001012")?;
 	assert_eq!(header.name(), "Block 1012");
 	assert_eq!(header.logrecno(), 19_200);
 


### PR DESCRIPTION
Closes #610.

It turns out that there is definitely a mismatch in the GEOID formats. For now, just store the 2010-style GEOIDs, though they are not unique at the SUMLEV. (The 2010 dataset was subject to the same constraint.)