### PR TITLE
Stabilize Coverage Computation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           LLVM_PROFILE_FILE: "distringo-%p-%m.profraw"
           RUSTFLAGS: >
-            -Zinstrument-coverage
+            -Cinstrument-coverage
       - name: Run grcov
         run: >
           grcov .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
           --binary-path ./target/debug/
           -t lcov
           --llvm
+          --log-level TRACE
           --branch
           --ignore-not-existing
           -o ./lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
             -Cinstrument-coverage
       - name: Run grcov
         run: >
-          grcov .
+          grcov . palapelify/.
           -s .
           --binary-path ./target/debug/
           -t lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run cargo build (to generate test targets)
         run: |
-          cargo build --workspace --all-features --all-targets --no-fail-fast
+          cargo build --workspace --all-features --all-targets
         env:
           RUSTFLAGS: >
             -Cinstrument-coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Install grcov
         run: cargo install grcov
       - uses: actions/checkout@v1
+      - name: Run cargo build (to generate test targets)
+        run: |
+          cargo build --workspace --all-features --all-targets --no-fail-fast
+        env:
+          RUSTFLAGS: >
+            -Cinstrument-coverage
       - name: Run tests with profiling
         run: |
           cargo test --workspace --all-features --all-targets --no-fail-fast

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run tests with profiling
         run: |
-          cargo test --workspace --all-features --no-fail-fast
+          cargo test --workspace --all-features --all-targets --no-fail-fast
         env:
           LLVM_PROFILE_FILE: "distringo-%p-%m.profraw"
           RUSTFLAGS: >


### PR DESCRIPTION
I've noticed a bunch of noise in the coverage graph:

![image](https://user-images.githubusercontent.com/1566689/170831990-79429cfe-4400-4bef-941a-0fdee7cd2828.png)

I suspect this is because we're not capturing the full thing, and maybe we're hitting a race condition or `grcov` isn't capturing everything.

This PR is an attempt to fix this.